### PR TITLE
ActiveRecord::Migrator.proper_table_name has been removed

### DIFF
--- a/lib/pg_power/create_index_concurrently.rb
+++ b/lib/pg_power/create_index_concurrently.rb
@@ -70,7 +70,7 @@ module PgPower::CreateIndexConcurrently
     #
     # @see ActiveRecord::ConnectionAdapters::SchemaStatements.add_index in pg_power gem
     def add_index(table_name, column_name, options = {}, &block)
-      table_name = ::ActiveRecord::Migrator.proper_table_name(table_name)
+      table_name = proper_table_name(table_name)
       # GOTCHA:
       #   checks if index should be created concurretnly then put it into
       #   the queue to wait till queue processing will be called (should be
@@ -108,7 +108,7 @@ module PgPower::CreateIndexConcurrently
     #
     # @see ::PgPower::ConnectionAdapters::PostgreSQLAdapter::ForeignerMethods.add_foreign_key
     def add_foreign_key(from_table, to_table, options = {}, &block)
-      from_table       = ::ActiveRecord::Migrator.proper_table_name(from_table)
+      from_table       = proper_table_name(from_table)
       concurrent_index = options[:concurrent_index]
 
       if concurrent_index then


### PR DESCRIPTION
## Why
`ActiveRecord::Migrator.proper_table_name` has been removed in  https://github.com/rails/rails/pull/15512.
So we have to use `ActiveRecord::Migration#proper_table_name` instead.

https://github.com/rails/rails/blob/4-2-stable/activerecord/lib/active_record/migration.rb#L717-L723


## What
- Use `ActiveRecord::Migration#proper_table_name` instead of `ActiveRecord::Migrator.proper_table_name`.